### PR TITLE
fix(zarinpal-http.ts): updated error section, handle empty array

### DIFF
--- a/src/core/services/zarinpal-http.ts
+++ b/src/core/services/zarinpal-http.ts
@@ -67,8 +67,7 @@ export class ZarinpalHttpClientService {
         this.verifyUrl,
         options,
       );
-
-      if (Array.isArray(request.errors) && request.errors.length > 0) {
+      if (request?.errors &&  Array.isArray(request.errors) && request.errors.length > 0) {
         throw new ZarinpalError(request.errors.code);
       }
 

--- a/src/core/services/zarinpal-http.ts
+++ b/src/core/services/zarinpal-http.ts
@@ -68,7 +68,7 @@ export class ZarinpalHttpClientService {
         options,
       );
 
-      if (request.errors) {
+      if (Array.isArray(request.errors) && request.errors.length > 0) {
         throw new ZarinpalError(request.errors.code);
       }
 


### PR DESCRIPTION
## Description

Thanks for your contribution. In new version of Zarinpal response, they sent empty array of errors and it made a bug on the application.

```
  data: {
    wages: [],
    code: 101,
    message: 'Verified',
    card_hash: 'XXXXX',
    card_pan: '11111*****111',
    ref_id: 5XXXXXXXX,
    fee_type: 'Merchant',
    fee: 3500,
    shaparak_fee: '1200',
    order_id: null
  },
  errors: []
```

Please check and fix this problem. Thanks
